### PR TITLE
Update DDL to resolve conflicts between _write() and standard library functions.

### DIFF
--- a/hc32_ddl/hc32f460/drivers/src/hc32_ll_utility.c
+++ b/hc32_ddl/hc32f460/drivers/src/hc32_ll_utility.c
@@ -9,6 +9,7 @@
    2022-06-30       CDT             Support re-target printf for IAR EW version 9 or later
    2023-06-30       CDT             Modify register USART DR to USART TDR
                                     Prohibit DDL_DelayMS and DDL_DelayUS functions from being optimized
+   2025-08-21       CDT             Convert _write() to weak
  @endverbatim
  *******************************************************************************
  * Copyright (C) 2022-2023, Xiaohua Semiconductor Co., Ltd. All rights reserved.
@@ -367,7 +368,7 @@ int32_t _write(int fd, char data[], int32_t size)
  *           - LL_ERR:                  The callback function pfnPreinit occurs error.
  *           - LL_ERR_INVD_PARAM:       The pointer pfnPreinit is NULL.
  */
-int32_t LL_PrintfInit(void *vpDevice, uint32_t u32Param, int32_t (*pfnPreinit)(void *vpDevice, uint32_t u32Param))
+__WEAKDEF int32_t LL_PrintfInit(void *vpDevice, uint32_t u32Param, int32_t (*pfnPreinit)(void *vpDevice, uint32_t u32Param))
 {
     int32_t i32Ret = LL_ERR_INVD_PARAM;
 

--- a/hc32_ddl/hc32f4a0/drivers/src/hc32_ll_utility.c
+++ b/hc32_ddl/hc32f4a0/drivers/src/hc32_ll_utility.c
@@ -9,6 +9,7 @@
    2022-06-30       CDT             Support re-target printf for IAR EW version 9 or later
    2023-06-30       CDT             Modify register USART DR to USART TDR
                                     Prohibit DDL_DelayMS and DDL_DelayUS functions from being optimized
+   2025-08-21       CDT             Convert _write() to weak
  @endverbatim
  *******************************************************************************
  * Copyright (C) 2022-2023, Xiaohua Semiconductor Co., Ltd. All rights reserved.
@@ -339,7 +340,7 @@ size_t __dwrite(int handle, const unsigned char *buffer, size_t size)
  * @param  [in] size
  * @retval int32_t
  */
-int32_t _write(int fd, char data[], int32_t size)
+__WEAKDEF int32_t _write(int fd, char data[], int32_t size)
 {
     int32_t i = -1;
 


### PR DESCRIPTION
The function _write() in hc32_ll_utility.c conflicts with other definitions. To resolve the compiling errors, make it a weak definition function.